### PR TITLE
chore: add default issue and PR template for TheFork org

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,46 @@
+name: 🐛 Bug report
+description: Create a report to help us improve
+labels: ['bug']
+
+body:
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+      - label: I have written a descriptive issue title
+        required: true
+      - label: |
+          I have searched existing issues to ensure the bug has not already been reported
+        required: true
+
+  - type: input
+    id: github-version
+    attributes:
+      label: Github version
+      placeholder: 3.x.x
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        List of steps, sample code, or a link to code or a project that reproduces the behavior.
+        Make sure you place a stack trace inside a [code (```) block](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) to avoid linking unrelated issues.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,0 +1,39 @@
+name: 📖 Documentation change
+description: Suggest a change to our documentation
+labels: ['docs']
+
+body:
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+      - label: I have written a descriptive issue title
+        required: true
+      - label: |
+          I have searched existing issues to ensure the doc change has not already been reported
+        required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 📖 Documentation change
+      description: A clear and concise description of what the doc change is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: The motivation for the proposal.
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example
+      description: |
+        An example for how this doc can be improved or added.
+        Make sure you place example code inside a [code (```) block](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) to avoid linking unrelated issues.
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,38 @@
+name: 🚀 Feature Proposal
+description: Submit a proposal for a new feature
+labels: ['enhancement']
+
+body:
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+      - label: I have written a descriptive issue title
+        required: true
+      - label: |
+          I have searched existing issues to ensure the feature has not already been requested
+        required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 🚀 Feature Proposal
+      description: A clear and concise description of what the feature is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: The motivation for the proposal.
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example
+      description: |
+        An example for how this feature would be used.
+        Make sure you place example code inside a [code (```) block](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) to avoid linking unrelated issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What?
+
+<!-- What changes did you make? (please link relevant tickets) -->
+
+## Why?
+
+<!-- What was the purpose of those changes? -->
+
+## How?
+
+<!-- Please provide more implementation details if needed -->
+
+### :white_check_mark: Checklist
+
+- [ ] I added tests and I checked that I have good coverage
+- [ ] Added documentation on code change (if required)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# .github
+# Community Health Files Repository
+
+This repository contains a set of organization-wide community health files. These files serve as
+organization-wide defaults for all repositories within their organization
+([details](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file)).


### PR DESCRIPTION
Add a default PR template, issue, bug and feature template for all TheFork org.

For the issue templates I followed fastify issue templates https://github.com/fastify/.github/tree/main/.github/ISSUE_TEMPLATE 

Example when you open a new issue https://github.com/fastify/.github/blob/main/.github/ISSUE_TEMPLATE/feature.yml

All these templates can be replaced by templates in `.github` folder in your repository.