### PR TITLE
chore: disable beacon auto issue creation

### DIFF
--- a/beacon.yml
+++ b/beacon.yml
@@ -1,0 +1,2 @@
+# Disable beacon auto issue creation in GitHub
+enabled: false


### PR DESCRIPTION
## Summary
- Add `beacon.yml` with `enabled: false` to disable Beacon's automatic issue creation in GitHub, matching the pattern used in [lafourchette/playwright-tests](https://github.com/lafourchette/playwright-tests/blob/master/beacon.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)